### PR TITLE
Reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Install Allure CLI
+        run: |
+          sudo apt-get update && sudo apt-get install -y default-jre
+          curl -o allure-2.27.0.tgz -L https://github.com/allure-framework/allure2/releases/download/2.27.0/allure-2.27.0.tgz
+          tar -xzf allure-2.27.0.tgz
+          sudo mv allure-2.27.0/bin/allure /usr/local/bin/
+          allure --version
+      - name: Build and test with Maven (TestNG suite)
+        run: mvn clean test allure:report
+      - name: Upload Allure Results (project root fallback)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-results-root
+          path: allure-results/
+      - name: Upload Allure Results (target)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-results
+          path: target/allure-results/
+      - name: Upload Allure HTML Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-report
+          path: target/site/allure-maven-plugin/
+      - name: Upload TestNG Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: target/surefire-reports/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    services:
-      selenium-hub:
-        image: selenium/hub:4.21.0-20240611
-        ports:
-          - 4444:4444
-      chrome:
-        image: selenium/node-chrome:4.21.0-20240611
-        env:
-          SE_EVENT_BUS_HOST: selenium-hub
-          SE_EVENT_BUS_PUBLISH_PORT: 4442
-          SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,16 +17,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Wait for Selenium Grid
-        run: |
-          for i in {1..30}; do
-            if curl -s http://localhost:4444/wd/hub/status | grep -q '"ready":true'; then
-              echo "Selenium Grid is ready!"
-              break
-            fi
-            echo "Waiting for Selenium Grid..."
-            sleep 2
-          done
       - name: Build and test with Maven (TestNG suite)
         run: mvn clean test allure:report
       - name: Generate Allure Report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
           SE_EVENT_BUS_HOST: selenium-hub
           SE_EVENT_BUS_PUBLISH_PORT: 4442
           SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
-        depends_on:
-          - selenium-hub
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      selenium-hub:
+        image: selenium/hub:4.21.0-20240611
+        ports:
+          - 4444:4444
+      chrome:
+        image: selenium/node-chrome:4.21.0-20240611
+        env:
+          SE_EVENT_BUS_HOST: selenium-hub
+          SE_EVENT_BUS_PUBLISH_PORT: 4442
+          SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
+        depends_on:
+          - selenium-hub
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -17,6 +30,16 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Wait for Selenium Grid
+        run: |
+          for i in {1..30}; do
+            if curl -s http://localhost:4444/wd/hub/status | grep -q '"ready":true'; then
+              echo "Selenium Grid is ready!"
+              break
+            fi
+            echo "Waiting for Selenium Grid..."
+            sleep 2
+          done
       - name: Build and test with Maven (TestNG suite)
         run: mvn clean test allure:report
       - name: Generate Allure Report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,27 +17,14 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Install Allure CLI
-        run: |
-          sudo apt-get update && sudo apt-get install -y default-jre
-          curl -o allure-2.27.0.tgz -L https://github.com/allure-framework/allure2/releases/download/2.27.0/allure-2.27.0.tgz
-          tar -xzf allure-2.27.0.tgz
-          sudo mv allure-2.27.0/bin/allure /usr/local/bin/
-          allure --version
       - name: Build and test with Maven (TestNG suite)
         run: mvn clean test allure:report
-      - name: Upload Allure Results (project root fallback)
-        if: always()
-        uses: actions/upload-artifact@v4
+      - name: Generate Allure Report
+        uses: simple-elf/allure-report-action@v1.8
         with:
-          name: allure-results-root
-          path: allure-results/
-      - name: Upload Allure Results (target)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: allure-results
-          path: target/allure-results/
+          allure_results: target/allure-results
+          allure_report: target/site/allure-maven-plugin
+          allure_history: allure-history
       - name: Upload Allure HTML Report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,60 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Allure results (project root and target)
+allure-results/
+target/allure-results/
+
+# Allure HTML reports
+allure-report/
+target/allure-report/
+target/site/allure-maven-plugin/
+
+# TestNG and Surefire reports
+surefire-reports/
+target/surefire-reports/
+
+# IntelliJ IDEA
+.idea/
+*.iml
+
+# VSCode
+.vscode/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Logs
+logs/
+*.log
+
+# Maven
+.mvn/
+target/
+
+# Node/npm (if ever used)
+node_modules/
+
+# Python (if ever used)
+__pycache__/
+*.pyc
+
+# Misc
+*.swp
+*.swo
+
+# Backup files
+*~
+*.bak
+
+# Build output
+build/
+
+# Coverage
+coverage/
+
+# Java crash logs
+hs_err_pid*
+replay_pid*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,87 @@
-# InterviewPrep
-Preparation for 2025
+# TestNG Base Project for Web and API Applications
+
+A Java Maven project for web application testing using Selenium WebDriver and TestNG.
+
+## Setup
+
+1. **Clone the repository:**
+   ```sh
+   git clone https://github.com/satishkovuru/TestNg-Web-API-Testing.git
+   cd TestNg-Web-API-Testing
+   ```
+
+2. **Install dependencies:**
+   ```sh
+   mvn clean install
+   ```
+
+3. **Configure Selenium Grid (if needed):**
+   - Ensure Selenium Grid is running at [http://localhost:4444](http://localhost:4444).
+
+4. **Edit configuration:**
+   - Update `src/test/resources/config.json` as needed (e.g., set `"baseUrl"`).
+
+## Usage
+
+- **Run all tests:**
+  ```sh
+  mvn test
+  ```
+
+- **Run with a specific TestNG suite:**
+  ```sh
+  mvn test -DsuiteXmlFile=src/test/resources/suites/testng.xml
+  ```
+
+- **Change browser:**
+  - Edit the `browser` parameter in `testng.xml` under `src/test/resources/suites/`.
+
+## Contribution
+
+1. Fork the repository.
+2. Create a new branch:
+   ```sh
+   git checkout -b feature/your-feature
+   ```
+3. Make your changes.
+4. Run tests and ensure code style passes:
+   ```sh
+   mvn spotless:check test
+   ```
+5. Commit and push:
+   ```sh
+   git push origin feature/your-feature
+   ```
+6. Open a pull request.
+
+## Code Style
+
+- Enforced via Spotless (Google Java Format).
+- Run `mvn spotless:apply` to auto-format code.
+
+## CI
+
+- GitHub Actions runs tests and code style checks on every push and pull request.
+- See `.github/workflows/ci.yml` for details.
+
+## Project Structure
+
+```
+src/main/java/        # Main source code (Page Objects, utilities)
+src/test/java/        # Test classes
+src/test/resources/   # Test resources (config, testng suites)
+```
+
+## Configuration
+
+`src/test/resources/config.json` example:
+```json
+{
+  "baseUrl": "https://www.google.com",
+  "anotherUrl": "https://example.com"
+}
+```
+
+## License
+
+This project is for educational purposes.

--- a/browserstack.yml
+++ b/browserstack.yml
@@ -1,0 +1,20 @@
+userName: satish_lqH2OK
+accessKey: ymXWZA8bEquxyLzuPL7E
+framework: testng
+platforms:
+  - os: Windows
+    osVersion: 11
+    browserName: Chrome
+    browserVersion: 118.0
+  - os: OS X
+    osVersion: Sonoma
+    browserName: Chrome
+    browserVersion: 119.0
+  - os: Windows
+    osVersion: 11
+    browserName: Edge
+    browserVersion: 118.0
+parallelsPerPlatform: 1
+browserstackLocal: true
+buildName: testng-test-browserstack-ci
+projectName: BrowserStack Sample

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="FinalLocalVariable"/>
+        <module name="EmptyBlock"/>
+        <module name="EqualsHashCode"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OneStatementPerLine"/>
+        <module name="ParameterName"/>
+        <module name="TypeName"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="tabWidth" value="4"/>
+        </module>
+    </module>
+    <module name="LineLength">
+        <property name="max" value="120"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>7.9.0</version>
-            <scope>test</scope>
+<!--            <scope>test</scope>-->
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -57,12 +57,19 @@
             <artifactId>webdrivermanager</artifactId>
             <version>6.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-testng</artifactId>
+            <version>2.24.0</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
+
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.0</version>
@@ -87,7 +94,34 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
                 <configuration>
-                    <skip>true</skip>
+                    <systemPropertyVariables>
+                        <allure.results.directory>${project.build.directory}/allure-results</allure.results.directory>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>2.11.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>checkstyle</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -15,20 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <selenium.version>4.35.0</selenium.version>
     </properties>
-    <repositories>
-        <repository>
-            <name>Central Portal Snapshots</name>
-            <id>central-portal-snapshots</id>
-            <url>https://repo1.maven.org/maven2//</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
 
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -63,11 +50,45 @@
             <version>2.24.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.browserstack</groupId>
+            <artifactId>browserstack-java-sdk</artifactId>
+            <version>LATEST</version>
+            <scope>compile</scope>
+        </dependency>
 
     </dependencies>
 
     <build>
         <plugins>
+                <!-- Maven Dependency Plugin -->
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>getClasspathFilenames</id>
+                            <goals>
+                                <goal>properties</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- Maven Surefire Plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
+                    <configuration>
+                        <suiteXmlFiles>
+                            <suiteXmlFile>src/test/resources/suites/testng.xml</suiteXmlFile>
+                        </suiteXmlFiles>
+                        <argLine>
+                            -javaagent:${com.browserstack:browserstack-java-sdk:jar}
+                        </argLine>
+                    </configuration>
+                </plugin>
+
             <plugin>
 
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/Page/HomePage.java
+++ b/src/main/java/Page/HomePage.java
@@ -1,12 +1,17 @@
 package Page;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.ConfigReader;
+
+import java.time.Duration;
 
 /**
  * Page Object Model for the application's home page.
@@ -54,11 +59,14 @@ public class HomePage {
      */
     public void search(String query) {
         try {
-            searchBox.sendKeys(query);
+            final WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+            final WebElement box = wait.until(ExpectedConditions.elementToBeClickable(By.name("q")));
+            box.clear();
+            box.sendKeys(query);
             logger.info("Entered search query: {}", query);
         } catch (Exception e) {
             logger.error("Failed to enter search query", e);
-            throw e;
+            throw new RuntimeException("Search box not interactable", e);
         }
     }
 

--- a/src/main/java/Page/HomePage.java
+++ b/src/main/java/Page/HomePage.java
@@ -1,42 +1,102 @@
 package Page;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import util.ConfigReader;
 
+/**
+ * Page Object Model for the application's home page.
+ * Encapsulates interactions with the home page elements and actions.
+ */
 public class HomePage {
-    private final WebDriver driver;
-    private final By searchBox = By.name("q");
-    private final By feelingLuckyButton = By.name("btnI");
+    /** SLF4J logger for logging actions and errors. */
+    private static final Logger logger = LoggerFactory.getLogger(HomePage.class);
 
+    /** WebDriver instance used for browser interactions. */
+    private final WebDriver driver;
+
+    /** Search box input field located by name 'q'. */
+    @FindBy(name = "q")
+    private WebElement searchBox;
+
+    /** "I'm Feeling Lucky" button located by name 'btnI'. */
+    @FindBy(name = "btnI")
+    private WebElement feelingLuckyButton;
+
+    /**
+     * Constructs a HomePage object and initializes web elements using PageFactory.
+     *
+     * @param driver the WebDriver instance to use
+     */
     public HomePage(WebDriver driver) {
         this.driver = driver;
+        PageFactory.initElements(driver, this);
     }
 
+    /**
+     * Navigates the browser to the home page URL specified in the configuration.
+     */
     public void navigateToHomePage() {
-        String baseUrl = ConfigReader.get("baseUrl");
+        final String baseUrl = ConfigReader.get("baseUrl");
         driver.get(baseUrl);
+        logger.info("Navigated to home page: {}", baseUrl);
     }
 
+    /**
+     * Enters the given search query into the search box.
+     *
+     * @param query the search query to enter
+     * @throws RuntimeException if unable to interact with the search box
+     */
     public void search(String query) {
-        driver.findElement(searchBox).sendKeys(query);
+        try {
+            searchBox.sendKeys(query);
+            logger.info("Entered search query: {}", query);
+        } catch (Exception e) {
+            logger.error("Failed to enter search query", e);
+            throw e;
+        }
     }
 
+    /**
+     * Interacts with the "I'm Feeling Lucky" button if it is visible and enabled.
+     *
+     * @throws RuntimeException if unable to interact with the button
+     */
     public void interactWithFeelingLucky() {
-        WebElement element = driver.findElement(feelingLuckyButton);
-        element.isDisplayed();
-        element.isEnabled();
-        element.isSelected();
+        try {
+            if (feelingLuckyButton.isDisplayed() && feelingLuckyButton.isEnabled()) {
+                feelingLuckyButton.isSelected();
+                logger.info("Interacted with 'I'm Feeling Lucky' button");
+            }
+        } catch (Exception e) {
+            logger.error("Failed to interact with 'I'm Feeling Lucky' button", e);
+            throw e;
+        }
     }
 
+    /**
+     * Retrieves the current page title.
+     *
+     * @return the title of the current page
+     */
     public String getPageTitle() {
-        String pageTitle = driver.getTitle();
-        System.out.println("Page title: " + pageTitle);
+        final String pageTitle = driver.getTitle();
+        logger.info("Page title: {}", pageTitle);
         return pageTitle;
     }
 
+    /**
+     * Quits the WebDriver instance, closing the browser.
+     */
     public void quit() {
-        driver.quit();
+        if (driver != null) {
+            driver.quit();
+            logger.info("WebDriver quit successfully");
+        }
     }
 }

--- a/src/main/java/util/ConfigReader.java
+++ b/src/main/java/util/ConfigReader.java
@@ -5,18 +5,30 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
+/**
+ * Utility class for reading configuration values from a JSON file.
+ * Loads the configuration from 'config.json' on the classpath at startup.
+ */
 public class ConfigReader {
+    /** Holds the configuration key-value pairs loaded from the JSON file. */
     private static Map<String, String> config;
 
+    // Static block to load configuration at class initialization
     static {
         try (InputStream input = ConfigReader.class.getClassLoader().getResourceAsStream("config.json")) {
-            ObjectMapper mapper = new ObjectMapper();
+            final ObjectMapper mapper = new ObjectMapper();
             config = mapper.readValue(input, Map.class);
         } catch (IOException e) {
             throw new RuntimeException("Failed to load config.json", e);
         }
     }
 
+    /**
+     * Retrieves the value for the specified configuration key.
+     *
+     * @param key the configuration key to look up
+     * @return the value associated with the key, or null if not found
+     */
     public static String get(String key) {
         return config.get(key);
     }

--- a/src/test/java/com/test/web/WepAppTest.java
+++ b/src/test/java/com/test/web/WepAppTest.java
@@ -1,7 +1,6 @@
 package com.test.web;
 
 import Page.HomePage;
-import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeOptions;
@@ -26,22 +25,6 @@ public class WepAppTest {
     private HomePage homePage;
 
     /**
-     * Helper to check if Selenium Grid is available.
-     */
-    private boolean isGridAvailable(String gridUrl) {
-        try {
-            URL url = new URL(gridUrl);
-            java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
-            conn.setConnectTimeout(2000);
-            conn.connect();
-            int code = conn.getResponseCode();
-            return code < 500; // Grid returns 200 or 4xx if up
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    /**
      * Sets up the WebDriver instance based on the specified browser.
      *
      * @param browser The name of the browser to use (e.g., "chrome", "firefox", "edge", "safari").
@@ -52,45 +35,26 @@ public class WepAppTest {
     public void setUp(@Optional("chrome") String browser) throws MalformedURLException {
         WebDriver driver;
         String gridUrl = System.getenv().getOrDefault("SELENIUM_GRID_URL", "http://localhost:4444/wd/hub");
-        boolean useGrid = isGridAvailable(gridUrl);
+        // Always use Selenium Grid
         try {
             if (browser.equalsIgnoreCase("chrome")) {
-                WebDriverManager.chromedriver().setup();
-                if (useGrid) {
-                    driver = new RemoteWebDriver(new URL(gridUrl), new ChromeOptions());
-                } else {
-                    driver = WebDriverManager.chromedriver().create();
-                }
+                driver = new RemoteWebDriver(new URL(gridUrl), new ChromeOptions());
             } else if (browser.equalsIgnoreCase("firefox")) {
-                WebDriverManager.firefoxdriver().setup();
-                if (useGrid) {
-                    driver = new RemoteWebDriver(new URL(gridUrl), new FirefoxOptions());
-                } else {
-                    driver = WebDriverManager.firefoxdriver().create();
-                }
+                driver = new RemoteWebDriver(new URL(gridUrl), new FirefoxOptions());
             } else if (browser.equalsIgnoreCase("edge")) {
-                WebDriverManager.edgedriver().setup();
                 EdgeOptions options = new EdgeOptions();
                 String userDataDir = System.getProperty("java.io.tmpdir") + "/edge_profile_" + System.currentTimeMillis();
                 options.addArguments("--user-data-dir=" + userDataDir);
-                if (useGrid) {
-                    driver = new RemoteWebDriver(new URL(gridUrl), options);
-                } else {
-                    driver = WebDriverManager.edgedriver().create();
-                }
+                driver = new RemoteWebDriver(new URL(gridUrl), options);
             } else if (browser.equalsIgnoreCase("safari")) {
-                if (useGrid) {
-                    driver = new RemoteWebDriver(new URL(gridUrl), new SafariOptions());
-                } else {
-                    driver = new org.openqa.selenium.safari.SafariDriver();
-                }
+                driver = new RemoteWebDriver(new URL(gridUrl), new SafariOptions());
             } else {
                 throw new IllegalArgumentException("Browser not supported: " + browser);
             }
             homePage = new HomePage(driver);
-            logger.info("WebDriver initialized for browser: {} (grid: {})", browser, useGrid);
+            logger.info("WebDriver initialized for browser: {}", browser);
         } catch (Exception e) {
-            logger.error("Failed to initialize WebDriver for browser: {} (grid: {})", browser, useGrid, e);
+            logger.error("Failed to initialize WebDriver for browser: {}", browser, e);
             throw e;
         }
     }

--- a/src/test/java/com/test/web/WepAppTest.java
+++ b/src/test/java/com/test/web/WepAppTest.java
@@ -1,6 +1,7 @@
 package com.test.web;
 
 import Page.HomePage;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeOptions;
@@ -15,67 +16,58 @@ import org.testng.annotations.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-/**
- * Test class for web application functionality.
- * Uses TestNG for test execution and Selenium WebDriver for browser automation.
- */
+
 public class WepAppTest {
 
     private static final Logger logger = LoggerFactory.getLogger(WepAppTest.class);
     private HomePage homePage;
 
-    /**
-     * Sets up the WebDriver instance based on the specified browser.
-     *
-     * @param browser The name of the browser to use (e.g., "chrome", "firefox", "edge", "safari").
-     * @throws MalformedURLException If the WebDriver URL is invalid.
-     */
-    @Parameters("browser")
+
+//    @Parameters("browser")
+//    @BeforeMethod(alwaysRun = true)
+//    public void setUp(@Optional("chrome") String browser) throws MalformedURLException {
+//        WebDriver driver;
+//        String gridUrl = System.getenv().getOrDefault("SELENIUM_GRID_URL", "http://localhost:4444/wd/hub");
+//        // Always use Selenium Grid
+//        try {
+//            if (browser.equalsIgnoreCase("chrome")) {
+//                driver = new RemoteWebDriver(new URL(gridUrl), new ChromeOptions());
+//            } else if (browser.equalsIgnoreCase("firefox")) {
+//                driver = new RemoteWebDriver(new URL(gridUrl), new FirefoxOptions());
+//            } else if (browser.equalsIgnoreCase("edge")) {
+//                EdgeOptions options = new EdgeOptions();
+//                String userDataDir = System.getProperty("java.io.tmpdir") + "/edge_profile_" + System.currentTimeMillis();
+//                options.addArguments("--user-data-dir=" + userDataDir);
+//                driver = new RemoteWebDriver(new URL(gridUrl), options);
+//            } else if (browser.equalsIgnoreCase("safari")) {
+//                driver = new RemoteWebDriver(new URL(gridUrl), new SafariOptions());
+//            } else {
+//                throw new IllegalArgumentException("Browser not supported: " + browser);
+//            }
+//            homePage = new HomePage(driver);
+//            logger.info("WebDriver initialized for browser: {}", browser);
+//        } catch (Exception e) {
+//            logger.error("Failed to initialize WebDriver for browser: {}", browser, e);
+//            throw e;
+//        }
+//    }
+
     @BeforeMethod(alwaysRun = true)
     public void setUp(@Optional("chrome") String browser) throws MalformedURLException {
         WebDriver driver;
-        String gridUrl = System.getenv().getOrDefault("SELENIUM_GRID_URL", "http://localhost:4444/wd/hub");
-        // Always use Selenium Grid
-        try {
-            if (browser.equalsIgnoreCase("chrome")) {
-                driver = new RemoteWebDriver(new URL(gridUrl), new ChromeOptions());
-            } else if (browser.equalsIgnoreCase("firefox")) {
-                driver = new RemoteWebDriver(new URL(gridUrl), new FirefoxOptions());
-            } else if (browser.equalsIgnoreCase("edge")) {
-                EdgeOptions options = new EdgeOptions();
-                String userDataDir = System.getProperty("java.io.tmpdir") + "/edge_profile_" + System.currentTimeMillis();
-                options.addArguments("--user-data-dir=" + userDataDir);
-                driver = new RemoteWebDriver(new URL(gridUrl), options);
-            } else if (browser.equalsIgnoreCase("safari")) {
-                driver = new RemoteWebDriver(new URL(gridUrl), new SafariOptions());
-            } else {
-                throw new IllegalArgumentException("Browser not supported: " + browser);
-            }
-            homePage = new HomePage(driver);
-            logger.info("WebDriver initialized for browser: {}", browser);
-        } catch (Exception e) {
-            logger.error("Failed to initialize WebDriver for browser: {}", browser, e);
-            throw e;
-        }
+        MutableCapabilities capabilities = new MutableCapabilities();
+        driver = new RemoteWebDriver(new URL("http://hub-cloud.browserstack.com/wd/hub"), capabilities);
+        homePage = new HomePage(driver);
+        logger.info("WebDriver initialized for browser: {}", browser);
     }
 
-    /**
-     * Provides test data for search queries.
-     *
-     * @return A two-dimensional array of objects, where each inner array contains
-     * a single search query string to be used as test data.
-     */
+
     @DataProvider(name = "searchQueries")
     public Object[][] searchQueries() {
         return new Object[][]{{"Selenium WebDriver"}, {"TestNG"}, {"PageFactory"}};
     }
 
-    /**
-     * Tests the application by navigating to the home page, performing a search,
-     * interacting with the "I'm Feeling Lucky" button, and verifying the page title.
-     *
-     * @param query The search query to use in the test.
-     */
+
     @Test(groups = "smoke", dataProvider = "searchQueries")
     public void launchApp(String query) {
         homePage.navigateToHomePage();
@@ -85,20 +77,13 @@ public class WepAppTest {
         Assert.assertEquals(title, "Google");
     }
 
-    /**
-     * Provides test data for invalid search queries.
-     *
-     * @return A two-dimensional array of objects, where each inner array contains
-     * a single invalid search query string to be used as test data.
-     */
+
     @DataProvider(name = "invalidSearchQueries")
     public Object[][] invalidSearchQueries() {
         return new Object[][]{{""}, {null}, {"   "}};
     }
 
-    /**
-     * Tests the application with invalid search queries (empty, null, whitespace).
-     */
+
     @Test(groups = "edge", dataProvider = "invalidSearchQueries")
     public void testInvalidSearchQueries(String query) {
         homePage.navigateToHomePage();

--- a/src/test/java/com/test/web/WepAppTest.java
+++ b/src/test/java/com/test/web/WepAppTest.java
@@ -8,49 +8,129 @@ import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.safari.SafariOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Parameters;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
+/**
+ * Test class for web application functionality.
+ * Uses TestNG for test execution and Selenium WebDriver for browser automation.
+ */
 public class WepAppTest {
 
+    private static final Logger logger = LoggerFactory.getLogger(WepAppTest.class);
     private HomePage homePage;
 
+    /**
+     * Sets up the WebDriver instance based on the specified browser.
+     *
+     * @param browser The name of the browser to use (e.g., "chrome", "firefox", "edge", "safari").
+     * @throws MalformedURLException If the WebDriver URL is invalid.
+     */
     @Parameters("browser")
     @BeforeMethod(alwaysRun = true)
-    public void setUp(String browser) throws MalformedURLException {
+    public void setUp(@Optional("chrome") String browser) throws MalformedURLException {
         WebDriver driver;
-        if (browser.equalsIgnoreCase("chrome")) {
-            WebDriverManager.chromedriver().setup();
-            driver = new RemoteWebDriver(new URL("http://localhost:4444"), new ChromeOptions());
-        } else if (browser.equalsIgnoreCase("firefox")) {
-            WebDriverManager.firefoxdriver().setup();
-            driver = new RemoteWebDriver(new URL("http://localhost:4444"), new FirefoxOptions());
-        } else if (browser.equalsIgnoreCase("edge")) {
-            WebDriverManager.edgedriver().setup();
-            EdgeOptions options = new EdgeOptions();
-            String userDataDir = System.getProperty("java.io.tmpdir") + "/edge_profile_" + System.currentTimeMillis();
-            options.addArguments("--user-data-dir=" + userDataDir);
-            driver = new RemoteWebDriver(new URL("http://localhost:4444"), options);
-        } else if (browser.equalsIgnoreCase("safari")) {
-            driver = new RemoteWebDriver(new URL("http://localhost:4444"), new SafariOptions());
-        } else {
-            throw new IllegalArgumentException("Browser not supported: " + browser);
+        try {
+            if (browser.equalsIgnoreCase("chrome")) {
+                WebDriverManager.chromedriver().setup();
+                driver = new RemoteWebDriver(new URL("http://localhost:4444"), new ChromeOptions());
+            } else if (browser.equalsIgnoreCase("firefox")) {
+                WebDriverManager.firefoxdriver().setup();
+                driver = new RemoteWebDriver(new URL("http://localhost:4444"), new FirefoxOptions());
+            } else if (browser.equalsIgnoreCase("edge")) {
+                WebDriverManager.edgedriver().setup();
+                EdgeOptions options = new EdgeOptions();
+                String userDataDir = System.getProperty("java.io.tmpdir") + "/edge_profile_" + System.currentTimeMillis();
+                options.addArguments("--user-data-dir=" + userDataDir);
+                driver = new RemoteWebDriver(new URL("http://localhost:4444"), options);
+            } else if (browser.equalsIgnoreCase("safari")) {
+                driver = new RemoteWebDriver(new URL("http://localhost:4444"), new SafariOptions());
+            } else {
+                throw new IllegalArgumentException("Browser not supported: " + browser);
+            }
+            homePage = new HomePage(driver);
+            logger.info("WebDriver initialized for browser: {}", browser);
+        } catch (Exception e) {
+            logger.error("Failed to initialize WebDriver for browser: {}", browser, e);
+            throw e;
         }
-        homePage = new HomePage(driver);
     }
 
-    @Test(groups = "smoke")
-    public void launchApp() {
+    /**
+     * Provides test data for search queries.
+     *
+     * @return A two-dimensional array of objects, where each inner array contains
+     * a single search query string to be used as test data.
+     */
+    @DataProvider(name = "searchQueries")
+    public Object[][] searchQueries() {
+        return new Object[][]{{"Selenium WebDriver"}, {"TestNG"}, {"PageFactory"}};
+    }
+
+    /**
+     * Tests the application by navigating to the home page, performing a search,
+     * interacting with the "I'm Feeling Lucky" button, and verifying the page title.
+     *
+     * @param query The search query to use in the test.
+     */
+    @Test(groups = "smoke", dataProvider = "searchQueries")
+    public void launchApp(String query) {
         homePage.navigateToHomePage();
-        homePage.search("Selenium WebDriver");
+        homePage.search(query);
         homePage.interactWithFeelingLucky();
         String title = homePage.getPageTitle();
         Assert.assertEquals(title, "Google");
-        homePage.quit();
+    }
+
+    /**
+     * Provides test data for invalid search queries.
+     *
+     * @return A two-dimensional array of objects, where each inner array contains
+     * a single invalid search query string to be used as test data.
+     */
+    @DataProvider(name = "invalidSearchQueries")
+    public Object[][] invalidSearchQueries() {
+        return new Object[][]{{""}, {null}, {"   "}};
+    }
+
+    /**
+     * Tests the application with invalid search queries (empty, null, whitespace).
+     */
+    @Test(groups = "edge", dataProvider = "invalidSearchQueries")
+    public void testInvalidSearchQueries(String query) {
+        homePage.navigateToHomePage();
+        try {
+            homePage.search(query);
+            homePage.interactWithFeelingLucky();
+            String title = homePage.getPageTitle();
+            Assert.assertNotNull(title);
+        } catch (Exception e) {
+            logger.warn("Exception occurred for invalid query: {}", query, e);
+            Assert.assertTrue(e instanceof IllegalArgumentException || e instanceof NullPointerException);
+        }
+    }
+
+    /**
+     * Tests setup with an unsupported browser name.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testUnsupportedBrowser() throws MalformedURLException {
+        setUp("unsupportedBrowser");
+    }
+
+    /**
+     * Cleans up the WebDriver instance after each test method.
+     * Ensures the browser is closed properly.
+     */
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        if (homePage != null) {
+            homePage.quit();
+        }
     }
 }

--- a/src/test/resources/suites/testng.xml
+++ b/src/test/resources/suites/testng.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="SampleSuite" parallel="tests" thread-count="5">
+    <listeners>
+        <listener class-name="io.qameta.allure.testng.AllureTestNg"/>
+    </listeners>
     <test name="ChromeTest">
         <parameter name="browser" value="chrome"/>
         <groups>
@@ -23,26 +26,5 @@
             <class name="com.test.web.WepAppTest"/>
         </classes>
     </test>
-<!--    <test name="EdgeTest">-->
-<!--        <parameter name="browser" value="edge"/>-->
-<!--        <groups>-->
-<!--            <run>-->
-<!--                <include name="smoke"/>-->
-<!--            </run>-->
-<!--        </groups>-->
-<!--        <classes>-->
-<!--            <class name="com.test.web.WepAppTest"/>-->
-<!--        </classes>-->
-<!--    </test>-->
-<!--    <test name="SafariTest">-->
-<!--        <parameter name="browser" value="safari"/>-->
-<!--        <groups>-->
-<!--            <run>-->
-<!--                <include name="smoke"/>-->
-<!--            </run>-->
-<!--        </groups>-->
-<!--        <classes>-->
-<!--            <class name="com.test.web.WepAppTest"/>-->
-<!--        </classes>-->
-<!--    </test>-->
+    <!-- Uncomment and add more browsers as needed -->
 </suite>


### PR DESCRIPTION
chore: update .gitignore for Java/Maven/Allure best practices

- Ignore all Maven build output by adding target/ to .gitignore, ensuring all generated files (including Allure results, HTML reports, Surefire reports, and other build artifacts) are not tracked by git.
- Explicitly ignore Allure results and reports in both project root and target/ (allure-results/, target/allure-results/, allure-report/, target/allure-report/, target/site/allure-maven-plugin/).
- Ignore Surefire and TestNG reports (surefire-reports/, target/surefire-reports/).
- Add common ignores for IDEs (IntelliJ .idea/, *.iml, VSCode .vscode/), OS files (.DS_Store, Thumbs.db), logs, backup files, build/ and coverage/ directories, Python/node/npm artifacts, and Java crash logs.
- Clean up and consolidate ignore rules for a cleaner repository and to prevent accidental commits of generated or environment-specific files.